### PR TITLE
Rename unit

### DIFF
--- a/src/gh_zeoslib.pas
+++ b/src/gh_zeoslib.pas
@@ -10,7 +10,7 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 }
 
-unit gh_DBZeos;
+unit gh_ZeosLib;
 
 {$i gh_def.inc}
 


### PR DESCRIPTION
Hello,

What you think about rename "gh_dbzeos.pas" unit to "gh_zeoslib.pas"? Yes, see "gh_sqldblib.pas", isnt "gh_dbsqldb.pas". :)

thx
